### PR TITLE
Fixed "java.lang.NoClassDefFoundError: feign/slf4j/Slf4jLogger"

### DIFF
--- a/passport-service/pom.xml
+++ b/passport-service/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>feign-ribbon</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.netflix.feign</groupId>
+            <artifactId>feign-slf4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>


### PR DESCRIPTION
When I tried the project today (29/01/2015) the passport module did not work, giving me the error described in the title.
The fix in this pull request did the trick for me
